### PR TITLE
refactor: remove unnecessary part and fix `module not found error`

### DIFF
--- a/packages/core/accounts/kernel/createKernelAccount.ts
+++ b/packages/core/accounts/kernel/createKernelAccount.ts
@@ -189,15 +189,14 @@ export async function createKernelAccount<
             enableData: plugin.getEnableData()
         })
 
-    // Fetch account address and chain id
-    const [accountAddress] = await Promise.all([
+    // Fetch account address
+    const accountAddress =
         deployedAccountAddress ??
-            getAccountAddress<TTransport, TChain>({
-                client,
-                entryPoint,
-                initCodeProvider: generateInitCode
-            })
-    ])
+        (await getAccountAddress<TTransport, TChain>({
+            client,
+            entryPoint,
+            initCodeProvider: generateInitCode
+        }))
 
     if (!accountAddress) throw new Error("Account address not found")
 

--- a/presets/index.ts
+++ b/presets/index.ts
@@ -1,0 +1,1 @@
+export * from "./zerodev"


### PR DESCRIPTION
### Summary
1. There was an issue where importing the presets package into another package resulted in successful compilation but led to a "Module not found" error at runtime. This is because there is no entrypoint index.ts file in rootdir. so I added it. 
2. Removed unnecessary async/await and promise.all